### PR TITLE
Add Python docstring formatters

### DIFF
--- a/packages/docformatter/package.yaml
+++ b/packages/docformatter/package.yaml
@@ -1,0 +1,16 @@
+---
+name: docformatter
+description: docformatter automatically formats docstrings to follow a subset of the PEP 257 conventions.
+homepage: https://pypi.org/project/docformatter/
+licenses:
+  - MIT
+languages:
+  - Python
+categories:
+  - Formatter
+
+source:
+  id: pkg:pypi/docformatter@1.6.5
+
+bin:
+  docformatter: pypi:docformatter

--- a/packages/pyment/package.yaml
+++ b/packages/pyment/package.yaml
@@ -1,0 +1,16 @@
+---
+name: pyment
+description: Create, update or convert docstrings in existing Python files, managing several styles.
+homepage: https://pypi.org/project/pyment/
+licenses:
+  - GPL-3.0-only
+languages:
+  - Python
+categories:
+  - Formatter
+
+source:
+  id: pkg:pypi/pyment@0.3.3
+
+bin:
+  pyment: pypi:pyment


### PR DESCRIPTION
Add docformatter and pyment Python docstring formatters to mason registry.